### PR TITLE
[bootloader/uart_driver] Adding uart watchdog to recover uart it receive

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,34 @@
 # Description of repository
 This is a repository that a custom stm32 bootloader is being developed.
 
+The bootloader is designed to have an easily portable core, by just replacing the driver layer, with the board specific one.
+The current implementation focuses on the STM32F401RE board.
+
+## Table of contents
+- [Bootloader features](#bootloader-features)
+- [Configuration](#configuration)
+- [Examples](#examples)
+- [How to use](#how-to-use)
+- [Repository structure](#repository-structure)
+
+# Bootloader features
+- Adaptable application space.
+- Checksum verification, before booting the application.
+- Authentication of the application. (Secure boot)
+- Easy to port to other microcontrollers.
+- Recovery mode (firmware update support).
+- Backup image recovery. If the main application is broken, the secondary is tested.
+- Secure communication through the custom communication protocol.
+
+# Configuration
+TODO.
+
+# Examples
+TODO.
+
+# How to use
+TODO.
+
 # Repository structure
 The structure of the repository is as follows:
 

--- a/projects/bootloader/CMakeLists.txt
+++ b/projects/bootloader/CMakeLists.txt
@@ -104,7 +104,7 @@ target_compile_options(${EXECUTABLE} PRIVATE
         -ffunction-sections
         -fstack-usage
         # Optimise for size
-        -Os
+        #-Os
         )
 
 get_target_property(COMPILE_OPTIONS ${EXECUTABLE} COMPILE_OPTIONS)

--- a/projects/bootloader/src/drivers/uart/uart_driver.c
+++ b/projects/bootloader/src/drivers/uart/uart_driver.c
@@ -164,9 +164,7 @@ HAL_UART_ErrorCallback(UART_HandleTypeDef *huart)
 {
     if (huart->Instance == USART2)
     {
-        HAL_UART_DeInit(&huart2);
-        HAL_UART_Init(&huart2);
-        HAL_UART_Receive_IT(&huart2, uart_buf.data_buffer, uart_buf.len);
+        uart_driver_rx_recover();
     }
 }
 
@@ -202,7 +200,6 @@ uart_driver_rx_recover(void)
     HAL_UART_Init(&huart2);
     // Restart the reception
     HAL_UART_Receive_IT(&huart2, uart_buf.data_buffer, uart_buf.len);
-    printf("Recovering uart reception\r\n");
 }
 
 /**


### PR DESCRIPTION
This commit is about adding uart watchdog. The TIM1 is used to clear the uart periodically, when the uart is inactive. It might be the case that some bytes are received (less than 256). If that happens, uart will still wait for the rest of the bytes until it receives 256, in order to parse them. This can create a permanent issue in uart communication.

After a period of inactivity, uart is reinitialized to expect again 256 bytes.